### PR TITLE
Add Python 3 support for newer distros

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,12 @@
 # Installs packages required for Ansible on Debian/Ubuntu hosts.
 #
 
-- name: Install minimal requirements for Ansible (on Debian/Ubuntu)
+- name: Install minimal requirements for Ansible (on Debian/Ubuntu).
   script: install_missing_package.sh {{item}}
   register: res
   changed_when: "res.stdout.startswith('Install')"
   with_items:
-     - python
-     - python-apt
-     - python-pycurl
-     - aptitude
+    - python3
+    - python3-apt
+    - python3-pycurl
+    - aptitude


### PR DESCRIPTION
Newer distributions use Python 3 by default and have renamed some specific Python packages.

This is basically same as https://github.com/ajsalminen/ansible-role-avahi_aliases/pull/3
